### PR TITLE
Export MaskRegions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { comparePdfToSnapshot } from './compare-pdf-to-snapshot'
+export { comparePdfToSnapshot, MaskRegions } from './compare-pdf-to-snapshot'


### PR DESCRIPTION
I would like to be able to reuse the `MaskRegions`  type in my own code that interfaces with `pdf-visual-diff`